### PR TITLE
Fixed font selection

### DIFF
--- a/assets/js/font.js
+++ b/assets/js/font.js
@@ -21,7 +21,7 @@ core.fontSelecter = function() {
     });
 
     // Disable light and medium font weight for condensed and monospace font faces
-    if (value === 'condensed' || value === 'monospace') {
+    if (demo.dataset.family === 'condensed' || demo.dataset.family === 'monospace') {
       options.forEach(function(option) {
         if (option.value === 'light' || option.value === 'medium') {
           option.disabled = true;

--- a/sass/_pattern_font-tester.scss
+++ b/sass/_pattern_font-tester.scss
@@ -36,7 +36,7 @@
 
       &[data-color="black"] { color: $color-dark; }
       &[data-color="aubergine"] { color: $color-aubergine; }
-      &[data-color="orange"] { color: $color-brand; }
+      &[data-color="orange"] { color: $color-accent; }
     }
   }
 }


### PR DESCRIPTION
## Done
Now:
- Font weight options stay disabled when trying different font weights
- When orange is selected as the font colour, the text turns ubuntu-orange instead of a very dark grey

## QA
- Run site
- On `/font` page:
    1. Select _Ubuntu Condensed_ as Family
    2. Select a different Weight
    3. See that the invalid Weight options are disabled
    4. Select again a Weight
    5. See that the invalid Weight options are still disabled
    6. Select _Orange_ as Color
    7. See that the colour of the text is orange

## Assumptions
As the orange colour scss variable `$color-brand` was defined in [vanilla-framework](/canonical/vanilla-framework) 's [_settings_colors.scss](/canonical/vanilla-framework/blob/main/scss/_settings_colors.scss#L185), I changed it to the correct (orange) variable in the [same file](/canonical/vanilla-framework/blob/main/scss/_settings_colors.scss#L188). If it's _better&trade;_ to be decoupled, inform me to change it accordingly.
