### PR TITLE
Removes white background onn text area

### DIFF
--- a/font/index.md
+++ b/font/index.md
@@ -83,7 +83,7 @@ body-class: fonts
           <option value="orange">Orange</option>
         </select>
       </div>
-      <textarea style="background-color: #ffffff;" class="font-tester__demo js-font-demo" data-size="16" data-family="ubuntu" data-weight="light" data-style="normal" data-color="black">
+      <textarea class="font-tester__demo js-font-demo" data-size="16" data-family="ubuntu" data-weight="light" data-style="normal" data-color="black">
 Type your text here
 
 Latin sample:


### PR DESCRIPTION
## Done

- Removes a inline styled white background from a textarea based on advice from Lyubo.

## QA

- Go to /font and check the text area has the latest vanilla style.

