### PR TITLE
WD-1299 use new vanilla layout on design ubuntu com site

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,16 +1,18 @@
-{% extends "_layouts/home.html" %}
+{% extends "_layouts/page-bare.html" %}
 
 {% block title %}404: Page not found{% endblock %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=365" alt="" width="365">
-    </div>
-    <div class="col-6">
-      <h1>404: Page not found</h1>
-      <p>Sorry, we couldn’t find that page.</p>
+<section class="p-strip is-deep is-bordered l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=365" alt="" width="365">
+      </div>
+      <div class="col-6">
+        <h1>404: Page not found</h1>
+        <p>Sorry, we couldn’t find that page.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/accessibility/index.html
+++ b/templates/accessibility/index.html
@@ -3,112 +3,132 @@
 {% block title %}Accessibility{% endblock %}
 
 {% block content %}
-<section class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-6">
-      <h1 class="p-heading--2">Accessibility</h1>
-    </div>
-    <div class="col-6">
-      <p>
-        We aim for Level AA conformance with the <br><a class="p-link--inverted" href="https://www.w3.org/TR/WCAG21/">Web Content
-        Accessibility Guidelines (WCAG) 2.1</a>
-      </p>
+<section class="p-strip--accent is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h1 class="p-heading--2">Accessibility</h1>
+      </div>
+      <div class="col-6">
+        <p>
+          We aim for Level AA conformance with the <br><a class="p-link--inverted" href="https://www.w3.org/TR/WCAG21/">Web Content
+          Accessibility Guidelines (WCAG) 2.1</a>
+        </p>
+      </div>
     </div>
   </div>
 </section>
+<div class="p-strip--light is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Ensuring conformance</h2>
+        <p>We use the following tools to continually audit the framework:</p>
+      </div>
+      <div class="col-6">
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a></p>
+        <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/TR/wai-aria-practices">WAI-ARIA Authoring Practices 1.1</a></p>
+        <p>
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> A guide for understanding how to use <cite><a href="https://www.w3.org/TR/wai-aria-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.1</a></cite> to create an accessible Rich Internet Application. It provides guidance on the appropriate application of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, describes recommended <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> usage patterns, and explains concepts behind them.</p>
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://validator.w3.org/nu/">The W3 Markup Validation Service</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Curated criteria checklist</h2>
+        <p class="u-no-padding--bottom">The scope of the WCAG spec can be overwhelming. We find the following checklist a good starting point if you're new to accessibility:</p>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="p-strip u-no-padding--top l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Make sure there is enough contrast between text and its background color</li>
+        <li class="p-list__item is-ticked">Don't indicate important information using colour alone</li>
+        <li class="p-list__item is-ticked">Design focus states to help users navigate and understand where they are</li>
+        <li class="p-list__item is-ticked">Links should be visually identifiable and have clearly distinct states</li>
+        <li class="p-list__item is-ticked">Be as consistent and clear as possible in layout and copy</li>
+        <li class="p-list__item is-ticked">The general architecture and hierarchy of the content should make sense</li>
 
-<div class="p-strip--light is-deep">
-  <div class="row">
-    <div class="col-6">
-      <h2>Ensuring conformance</h2>
-      <p>We use the following tools to continually audit the framework:</p>
-    </div>
-    <div class="col-6">
-      <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a></p>
-      <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
-      <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/TR/wai-aria-practices">WAI-ARIA Authoring Practices 1.1</a></p>
-      <p>
-        <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> A guide for understanding how to use <cite><a href="https://www.w3.org/TR/wai-aria-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.1</a></cite> to create an accessible Rich Internet Application. It provides guidance on the appropriate application of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, describes recommended <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> usage patterns, and explains concepts behind them.</p>
-      <p class="p-heading--5 u-no-margin--bottom"><a href="https://validator.w3.org/nu/">The W3 Markup Validation Service</a></p>
-    </div>
-  </div>
-</div>
+        <li class="p-list__item is-ticked">Help users understand inputs, and help them avoid and correct mistakes</li>
+        <li class="p-list__item is-ticked">Write good alt text for your images</li>
+        <li class="p-list__item is-ticked">Make links descriptive</li>
+        <li class="p-list__item is-ticked">Users should be able to navigate content using a screen reader</li>
+        <li class="p-list__item is-ticked">If an experience cannot be made accessible, create another route for users to get that information</li>
 
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Curated criteria checklist</h2>
-      <p class="u-no-padding--bottom">The scope of the WCAG spec can be overwhelming. We find the following checklist a good starting point if you're new to accessibility:</p>
-    </div>
-  </div>
-</div>
-<div class="p-strip u-no-padding--top">
-  <div class="u-fixed-width">
-    <ul class="p-list is-split">
-      <li class="p-list__item is-ticked">Make sure there is enough contrast between text and its background color</li>
-      <li class="p-list__item is-ticked">Don't indicate important information using colour alone</li>
-      <li class="p-list__item is-ticked">Design focus states to help users navigate and understand where they are</li>
-      <li class="p-list__item is-ticked">Links should be visually identifiable and have clearly distinct states</li>
-      <li class="p-list__item is-ticked">Be as consistent and clear as possible in layout and copy</li>
-      <li class="p-list__item is-ticked">The general architecture and hierarchy of the content should make sense</li>
-
-      <li class="p-list__item is-ticked">Help users understand inputs, and help them avoid and correct mistakes</li>
-      <li class="p-list__item is-ticked">Write good alt text for your images</li>
-      <li class="p-list__item is-ticked">Make links descriptive</li>
-      <li class="p-list__item is-ticked">Users should be able to navigate content using a screen reader</li>
-      <li class="p-list__item is-ticked">If an experience cannot be made accessible, create another route for users to get that information</li>
-
-      <li class="p-list__item is-ticked">Use the correct HTML element for your content</li>
-      <li class="p-list__item is-ticked">Support keyboard navigation</li>
-      <li class="p-list__item is-ticked">Understand and use region landmarks</li>
-      <li class="p-list__item is-ticked">Unless all your content is inside region markups, give users a way to skip top level navigation to access main content</li>
-      <li class="p-list__item is-ticked">Use ARIA roles, properties and states when applicable</li>
-      <li class="p-list__item is-ticked">Avoid images and iconography in pseudo-elements</li>
-      <li class="p-list__item is-ticked">Hide decorative elements from screen readers</li>
-      <li class="p-list__item is-ticked">Make SVGs accessible to assistive technology</li>
-      <li class="p-list__item is-ticked">HTML document should have a language attribute</li>
-    </ul>
-    <p>*Adapted from <a href="http://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="http://a11yproject.com/checklist.html">Web Accessibility Checklist</a></p>
-  </div>
-</div>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Key WCAG documents</h2>
-      <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
-    </div>
-  </div>
-</div>
-<div class="p-strip u-no-padding--top">
-  <div class="row">
-    <ul class="p-list is-split">
-      <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
-      <li class="p-list__item"><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</li>
-      <li class="p-list__item"><a href="https://www.w3.org/WAI/WCAG20/quickref/">How to Meet WCAG 2.0</a>: a customisable quick reference, includes guidelines, success criteria and techniques</li>
-      <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a>: instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</li>
-    </ul>
-  </div>
-</div>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Useful tools</h2>
-      <p>The web is abundant in tools that help to create and test for accessible sites. We find the following particularly useful:</p>
-    </div>
-    <div class="col-6">
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
-        <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>
-        <li class="p-list__item"><a href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
-        <li class="p-list__item"><a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>
-        <li class="p-list__item"><a href="https://webaim.org/">Web Accessibility in Mind</a></li>
+        <li class="p-list__item is-ticked">Use the correct HTML element for your content</li>
+        <li class="p-list__item is-ticked">Support keyboard navigation</li>
+        <li class="p-list__item is-ticked">Understand and use region landmarks</li>
+        <li class="p-list__item is-ticked">Unless all your content is inside region markups, give users a way to skip top level navigation to access main content</li>
+        <li class="p-list__item is-ticked">Use ARIA roles, properties and states when applicable</li>
+        <li class="p-list__item is-ticked">Avoid images and iconography in pseudo-elements</li>
+        <li class="p-list__item is-ticked">Hide decorative elements from screen readers</li>
+        <li class="p-list__item is-ticked">Make SVGs accessible to assistive technology</li>
+        <li class="p-list__item is-ticked">HTML document should have a language attribute</li>
       </ul>
+      <p>*Adapted from <a href="http://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="http://a11yproject.com/checklist.html">Web Accessibility Checklist</a></p>
+    </div>
+  </div>  
+</div>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom">
+    </div>
+  </div>
+</div>
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Key WCAG documents</h2>
+        <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="p-strip u-no-padding--top l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <ul class="p-list is-split">
+        <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
+        <li class="p-list__item"><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</li>
+        <li class="p-list__item"><a href="https://www.w3.org/WAI/WCAG20/quickref/">How to Meet WCAG 2.0</a>: a customisable quick reference, includes guidelines, success criteria and techniques</li>
+        <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a>: instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</li>
+      </ul>
+    </div>
+  </div>
+</div>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom">
+    </div>
+  </div>
+</div>
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Useful tools</h2>
+        <p>The web is abundant in tools that help to create and test for accessible sites. We find the following particularly useful:</p>
+      </div>
+      <div class="col-6">
+        <ul class="p-list--divided">
+          <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
+          <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>
+          <li class="p-list__item"><a href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
+          <li class="p-list__item"><a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>
+          <li class="p-list__item"><a href="https://webaim.org/">Web Accessibility in Mind</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/contribute/index.html
+++ b/templates/contribute/index.html
@@ -3,76 +3,88 @@
 {% block title %}Contribute{% endblock %}
 
 {% block content %}
-<section class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h1 class="p-heading--2">Contribute</h1>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>
-        You can use our open-source design system to build any website or product. At Canonical we are always working to
-        improve and update it. Here are some ways in which you can contribute:
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h2>Propose a change</h2>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>
-        If you have found a bug on the site or have an idea for a new feature, feel free to <a
-              href="https://github.com/canonical/design.ubuntu.com/issues">create a new issue</a>, or
-        suggest a fix by creating a pull request.
-      </p>
-      <p>
-        Please provide as much information possible detailing what you're currently experiencing and what you'd expect
-        to experience.
-      </p>
+<section class="p-strip--accent is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h1 class="p-heading--2">Contribute</h1>
+      </div>
+      <div class="col-6 col-medium-4">
+        <p>
+          You can use our open-source design system to build any website or product. At Canonical we are always working to
+          improve and update it. Here are some ways in which you can contribute:
+        </p>
+      </div>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h2>Propose a new component or pattern</h2>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>
-        If you find that you can't design a particular functionality by using our existing components or patterns, we
-        encourage you to file an issue in the Vanilla Github repo. You can either propose a new component or pattern, or
-        suggest
-        amends to existing ones.
-      </p>
-      <p>
-        Internally, we have a working group which will look at your proposal and discuss whether there are alternative
-        ways of accomplishing your goals with existing components, or validate your request. Once your request has been
-        validated one of our designers will take ownership of this issue and work on providing a solution.
-      </p>
-      <a href="https://github.com/canonical/vanilla-framework/issues">Submit a new issue</a>
+<section class="p-strip--light is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>Propose a change</h2>
+      </div>
+      <div class="col-6 col-medium-4">
+        <p>
+          If you have found a bug on the site or have an idea for a new feature, feel free to <a
+                href="https://github.com/canonical/design.ubuntu.com/issues">create a new issue</a>, or
+          suggest a fix by creating a pull request.
+        </p>
+        <p>
+          Please provide as much information possible detailing what you're currently experiencing and what you'd expect
+          to experience.
+        </p>
+      </div>
     </div>
   </div>
 </section>
 
-<div class="row">
-  <hr />
+<section class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>Propose a new component or pattern</h2>
+      </div>
+      <div class="col-6 col-medium-4">
+        <p>
+          If you find that you can't design a particular functionality by using our existing components or patterns, we
+          encourage you to file an issue in the Vanilla Github repo. You can either propose a new component or pattern, or
+          suggest
+          amends to existing ones.
+        </p>
+        <p>
+          Internally, we have a working group which will look at your proposal and discuss whether there are alternative
+          ways of accomplishing your goals with existing components, or validate your request. Once your request has been
+          validated one of our designers will take ownership of this issue and work on providing a solution.
+        </p>
+        <a href="https://github.com/canonical/vanilla-framework/issues">Submit a new issue</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="l-full-width">
+  <div class="main">
+    <div class="row">
+      <hr />
+    </div>
+  </div>
 </div>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h2>Request a resource and logo</h2>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel mi sed nibh ullamcorper maximus dictum
-        varius ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel mi sed nibh ullamcorper
-        maximus dictum varius ligula.
-      </p>
+<section class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>Request a resource and logo</h2>
+      </div>
+      <div class="col-6 col-medium-4">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel mi sed nibh ullamcorper maximus dictum
+          varius ligula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel mi sed nibh ullamcorper
+          maximus dictum varius ligula.
+        </p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/font/index.html
+++ b/templates/font/index.html
@@ -3,94 +3,99 @@
 {% block title %}Ubuntu font{% endblock %}
 
 {% block content %}
-<section class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h1 class="p-heading--2">Ubuntu font</h1>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>The way typography is used says as much about our brand as the words themselves.</p>
-      <p>The Ubuntu typeface has been specially created to complement the Ubuntu tone of voice. It has a contemporary style and contains characteristics unique to the Ubuntu brand that convey a precise, reliable and free attitude.</p>
+<section class="p-strip--accent is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h1 class="p-heading--2">Ubuntu font</h1>
+      </div>
+      <div class="col-6 col-medium-4">
+        <p>The way typography is used says as much about our brand as the words themselves.</p>
+        <p>The Ubuntu typeface has been specially created to complement the Ubuntu tone of voice. It has a contemporary style and contains characteristics unique to the Ubuntu brand that convey a precise, reliable and free attitude.</p>
+      </div>
     </div>
   </div>
 </section>
-<section class="p-strip--light is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h2>Font Variants</h2>
-      <p>We use the Ubuntu font family by default, but you can specify any other font family to better suit your project.</p>
-    </div>
-    <div class="col-8 col-medium-4">
-      <div class="row u-equal-height">
-        <div class="col-4 p-card is-light">
-          <h3 class="p-card__title">Ubuntu</h3>
-          <p style="font-size: 24px;">It’s no use going back to yesterday, because I was a different person then.</p>
-        </div>
-        <div class="col-4 p-card">
-          <h3 class="p-card__title" style="font-family: 'Ubuntu Mono';">Ubuntu Monospace</h3>
-          <p style="font-family: 'Ubuntu Mono'; font-size: 16px;">
-            A: Would you tell me, please, which way I ought to go from here?<br /> C: That depends a good deal on where you want to get to.
-          </p>
+<section class="p-strip--light is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>Font Variants</h2>
+        <p>We use the Ubuntu font family by default, but you can specify any other font family to better suit your project.</p>
+      </div>
+      <div class="col-8 col-medium-4">
+        <div class="row u-equal-height">
+          <div class="col-4 p-card is-light">
+            <h3 class="p-card__title">Ubuntu</h3>
+            <p style="font-size: 24px;">It’s no use going back to yesterday, because I was a different person then.</p>
+          </div>
+          <div class="col-4 p-card">
+            <h3 class="p-card__title" style="font-family: 'Ubuntu Mono';">Ubuntu Monospace</h3>
+            <p style="font-family: 'Ubuntu Mono'; font-size: 16px;">
+              A: Would you tell me, please, which way I ought to go from here?<br /> C: That depends a good deal on where you want to get to.
+            </p>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </section>
-<section class="p-strip is-deep ">
-  <div class="row">
-    <div class="col-8">
-      <h2>Ubuntu font tester</h2>
-      <p>
-        The family supports the full Latin, Cyrillic and Greek alphabets, as well as Esperanto, with combining diacritical marks and a wide range of punctuation.
-      </p>
-    </div>
-    <div>
-      <label for="family">Family</label>
-      <select class="js-font-select" name="family" onchange="updateFontVariations()">
-        <option value="ubuntu" selected>Ubuntu</option>
-        <option value="monospace">Ubuntu Monospace</option>
-      </select>
-    </div>
-    <div>
-      <label for="style">Style</label>
-      <select class="js-font-select" name="style" onchange="updateFontVariations()">
-        <option value="normal" selected>Normal</option>
-        <option value="italic">Italic</option>
-      </select>
-    </div>
-    <div>
-      <label for="size">Size (<span id="size_tag">16px</span>)</label>
-      <input 
-        id="size" 
-        type="range" 
-        min="8" 
-        max="48" 
-        value="16" 
-        step="1" 
-        style="appearance: auto" 
-        oninput="updateFontVariations()"
+<section class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-8">
+        <h2>Ubuntu font tester</h2>
+        <p>
+          The family supports the full Latin, Cyrillic and Greek alphabets, as well as Esperanto, with combining diacritical marks and a wide range of punctuation.
+        </p>
+      </div>
+      <div>
+        <label for="family">Family</label>
+        <select class="js-font-select" name="family" onchange="updateFontVariations()">
+          <option value="ubuntu" selected>Ubuntu</option>
+          <option value="monospace">Ubuntu Monospace</option>
+        </select>
+      </div>
+      <div>
+        <label for="style">Style</label>
+        <select class="js-font-select" name="style" onchange="updateFontVariations()">
+          <option value="normal" selected>Normal</option>
+          <option value="italic">Italic</option>
+        </select>
+      </div>
+      <div>
+        <label for="size">Size (<span id="size_tag">16px</span>)</label>
+        <input 
+          id="size" 
+          type="range" 
+          min="8" 
+          max="48" 
+          value="16" 
+          step="1" 
+          style="appearance: auto" 
+          oninput="updateFontVariations()"
+        >
+      </div>
+      <div>
+        <label for="weight">Weight (<span id="weight_tag">400</span>)</label>
+        <input 
+          id="weight" 
+          type="range" 
+          min="100" 
+          max="800" 
+          value="400" 
+          step="1" 
+          style="appearance: auto" 
+          oninput="updateFontVariations()"
+        >
+      </div>
+      <textarea 
+        id="font-tester"
+        class="font-tester__demo js-font-demo"
+        data-family="ubuntu" 
+        data-style="normal" 
+        data-color="black"
       >
-    </div>
-    <div>
-      <label for="weight">Weight (<span id="weight_tag">400</span>)</label>
-      <input 
-        id="weight" 
-        type="range" 
-        min="100" 
-        max="800" 
-        value="400" 
-        step="1" 
-        style="appearance: auto" 
-        oninput="updateFontVariations()"
-      >
-    </div>
-    <textarea 
-      id="font-tester"
-      class="font-tester__demo js-font-demo"
-      data-family="ubuntu" 
-      data-style="normal" 
-      data-color="black"
-    >
 Type your text here
 
 Latin sample:
@@ -101,107 +106,114 @@ Cyrillic sample:
 
 Greek sample:
 Λορεμ ιπσθμ δολορ σιτ αμετ, μεα νατθμ ηαβεμθσ νο σιτ.
-    </textarea>
+      </textarea>
+    </div>
   </div>
 </section>
 
-<div class="p-strip--accent is-dark is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h2>About the Ubuntu font family</h2>
-    </div>
-    <div class="col-8 col-medium-4">
-      <p>The Ubuntu font family are a set of matching new libre/open fonts. The development is being funded by <a href="http://www.canonical.com/" class="p-link--inverted">Canonical</a> on behalf the wider Free Software community and the Ubuntu project.
-        The technical font design work and implementation is being undertaken by <a href="http://www.daltonmaag.com/" class="p-link--inverted">Dalton&nbsp;Maag</a>.</p>
-      <p>Both the final font Truetype/OpenType files and the design files used to produce the font family are distributed under an <a href="http://www.ubuntu.com/legal/terms-and-policies/font-licence" class="p-link--inverted">open licence</a> and you are
-        expressly encouraged to experiment, modify, share and improve. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.</p>
-      <p>The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu&apos;s philosophy which states that every user should be able to use their software in the language of their choice.
-        So the Ubuntu Font Family project will be extended to cover many more written languages.</p>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip--light is-deep is-bordered">
-  <div class="row">
-    <div class="col-8 u-sv3">
-      <h2>Facts and figures</h2>
-      <p>
-        The Ubuntu font family is a sans-serif typeface family available in 22 styles plus a variable font with adjustable weight and width axes. . Its fixed-width companion, Ubuntu Mono, comes in 8 styles and a variable font with an adjustable weight axis.
-      </p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h3>Coverage</h3>
-    </div>
-    <div class="col-8 col-medium-4">
-      <p>1,200 glyphs, 200-250 languages (native languages of 3 billion people!).</p>
-    </div>
-  </div>
-  <div class="row u-sv3">
-    <hr />
-  </div>
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h3>Technology</h3>
-    </div>
-    <div class="col-8 col-medium-4">
-      <p>
-        The pixels-per-em 7-segment digits are driven by the hint engine (substituted from the DejaVu fonts), so if hinting is by default off (e.g. Firefox) then the output will show as a pair of &ldquo;88&rdquo; numerals.
-      </p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">OpenType-based TTF (TrueType)</li>
-        <li class="p-list__item is-ticked">Variable fonts</li>
-        <li class="p-list__item is-ticked">
-          Alternative glyphs (e.g. proportional/non-proportional/superscript/subscript numerals)
-        </li>
-      </ul>
-    </div>
-  </div>
-  <div class="row u-sv3">
-    <hr />
-  </div>
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h3>Design</h3>
-    </div>
-    <div class="col-8 col-medium-4">
-      <p>
-        The four Latin characters, &apos;n o H O&apos; helped to define a guide for around 80-percent of the remaining characters.
-      </p>
-      <p>Software used:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">
-          Fontlab Studio, 
-          <a href="http://robofont.com" rel="noopener noreferrer">RoboFonts</a>, 
-          <a href="https://glyphsapp.com" rel="noopener noreferrer">Glyphs</a>
-        </li>
-        <li class="p-list__item is-ticked">
-          Automated build process based on 
-          <a href="https://github.com/googlefonts/gftools" rel="noopener noreferrer">gftools</a>, 
-          <a href="https://github.com/googlefonts/fontmake" rel="noopener noreferrer">fontmake</a>, 
-          <a href="https://github.com/fonttools/fonttools" rel="noopener noreferrer">fontTools</a>
-        </li>
-        <li class="p-list__item is-ticked">In-house Python-based scripts</li>
-      </ul>
+<div class="p-strip--accent is-dark is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>About the Ubuntu font family</h2>
+      </div>
+      <div class="col-8 col-medium-4">
+        <p>The Ubuntu font family are a set of matching new libre/open fonts. The development is being funded by <a href="http://www.canonical.com/" class="p-link--inverted">Canonical</a> on behalf the wider Free Software community and the Ubuntu project.
+          The technical font design work and implementation is being undertaken by <a href="http://www.daltonmaag.com/" class="p-link--inverted">Dalton&nbsp;Maag</a>.</p>
+        <p>Both the final font Truetype/OpenType files and the design files used to produce the font family are distributed under an <a href="http://www.ubuntu.com/legal/terms-and-policies/font-licence" class="p-link--inverted">open licence</a> and you are
+          expressly encouraged to experiment, modify, share and improve. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.</p>
+        <p>The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu&apos;s philosophy which states that every user should be able to use their software in the language of their choice.
+          So the Ubuntu Font Family project will be extended to cover many more written languages.</p>
+      </div>
     </div>
   </div>
 </div>
 
-<section class="p-strip is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h2>Resources</h2>
+<div class="p-strip--light is-deep is-bordered l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-8 u-sv3">
+        <h2>Facts and figures</h2>
+        <p>
+          The Ubuntu font family is a sans-serif typeface family available in 22 styles plus a variable font with adjustable weight and width axes. . Its fixed-width companion, Ubuntu Mono, comes in 8 styles and a variable font with an adjustable weight axis.
+        </p>
+      </div>
     </div>
-    <div class="col-8 col-medium-4">
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip">Download the Ubuntu Font Family</a> (2.2MB)</li>
-        <li class="p-list__item"><p><a href="https://assets.ubuntu.com/v1/0f5898c1-ubuntu-font-family-sources_0.83.orig.tar.gz">Download the Ubuntu Font Family source code</a></p> (For font designers with a copy of Font Lab Studio, 8.4MB)</li>
-        <li class="p-list__item"><a href="https://fonts.google.com/?query=Ubuntu">Google Fonts</a></li>
-        <li class="p-list__item"><a href="http://launchpad.net/ubuntu-font-family">Launchpad</a></li>
-        <li class="p-list__item"><a href="http://wiki.ubuntu.com/Ubuntu_Font_Family">Wiki documentation</a></li>
-      </ul>
-      <p><a href="https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip" class="p-button--positive">Download for free</a></p>
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h3>Coverage</h3>
+      </div>
+      <div class="col-8 col-medium-4">
+        <p>1,200 glyphs, 200-250 languages (native languages of 3 billion people!).</p>
+      </div>
+    </div>
+    <div class="row u-sv3">
+      <hr />
+    </div>
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h3>Technology</h3>
+      </div>
+      <div class="col-8 col-medium-4">
+        <p>
+          The pixels-per-em 7-segment digits are driven by the hint engine (substituted from the DejaVu fonts), so if hinting is by default off (e.g. Firefox) then the output will show as a pair of &ldquo;88&rdquo; numerals.
+        </p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">OpenType-based TTF (TrueType)</li>
+          <li class="p-list__item is-ticked">Variable fonts</li>
+          <li class="p-list__item is-ticked">
+            Alternative glyphs (e.g. proportional/non-proportional/superscript/subscript numerals)
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="row u-sv3">
+      <hr />
+    </div>
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h3>Design</h3>
+      </div>
+      <div class="col-8 col-medium-4">
+        <p>
+          The four Latin characters, &apos;n o H O&apos; helped to define a guide for around 80-percent of the remaining characters.
+        </p>
+        <p>Software used:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">
+            Fontlab Studio, 
+            <a href="http://robofont.com" rel="noopener noreferrer">RoboFonts</a>, 
+            <a href="https://glyphsapp.com" rel="noopener noreferrer">Glyphs</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            Automated build process based on 
+            <a href="https://github.com/googlefonts/gftools" rel="noopener noreferrer">gftools</a>, 
+            <a href="https://github.com/googlefonts/fontmake" rel="noopener noreferrer">fontmake</a>, 
+            <a href="https://github.com/fonttools/fonttools" rel="noopener noreferrer">fontTools</a>
+          </li>
+          <li class="p-list__item is-ticked">In-house Python-based scripts</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>Resources</h2>
+      </div>
+      <div class="col-8 col-medium-4">
+        <ul class="p-list--divided">
+          <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip">Download the Ubuntu Font Family</a> (2.2MB)</li>
+          <li class="p-list__item"><p><a href="https://assets.ubuntu.com/v1/0f5898c1-ubuntu-font-family-sources_0.83.orig.tar.gz">Download the Ubuntu Font Family source code</a></p> (For font designers with a copy of Font Lab Studio, 8.4MB)</li>
+          <li class="p-list__item"><a href="https://fonts.google.com/?query=Ubuntu">Google Fonts</a></li>
+          <li class="p-list__item"><a href="http://launchpad.net/ubuntu-font-family">Launchpad</a></li>
+          <li class="p-list__item"><a href="http://wiki.ubuntu.com/Ubuntu_Font_Family">Wiki documentation</a></li>
+        </ul>
+        <p><a href="https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip" class="p-button--positive">Download for free</a></p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{% extends "_layouts/home.html" %}
+{% extends "_layouts/page-bare.html" %}
 
 {% block title %}Ubuntu Design{% endblock %}
 

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -90,7 +90,7 @@ block content %}
           {% endfor %}
         </div>
         <div class="col-4 col-medium-4">
-          <label class="p-switch">
+          <label class="p-switch u-hide--medium u-hide--small">
             <input 
               type="checkbox" 
               class="p-switch__input" 

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -1,224 +1,230 @@
 {% extends "_layouts/page-bare.html" %} {% block title %}Resources{% endblock %} {%
 block content %}
-<section class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <h1 class="p-heading--2">Design resources</h1>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>
-        On this page you will find everything you need to design and build with our design system, including our Figma component library, our icon library and the Ubuntu font.
-      </p>
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-deep">
-  <div class="row">
-    <div class="col-4 col-medium-2">
-      <div class="col-3 col-medium-2">
-        <h2>Design system library</h2>
-      </div>
-      <div class="col-1 u-hide--medium u-hide--small"></div>
-    </div>
-    <div class="col-6 col-medium-4">
-      <p>
-        In this Figma library you will find our most up-to-date responsive components to build your designs.
-      </p>
-      <p>
-        <a
-          href="https://www.figma.com/file/H6MSsN3taoXXOJCPUbIImQ/Design-System-Library?node-id=803%3A9310&t=W0OglotYBvqZyM1e-1"
-        >
-          View our Figma library
-        </a>
-      </p>
-    </div>
-  </div>
-</section>
-<div class="p-strip is-deep">
-  <div class="row">
-    <h2>Brand resources</h2>
-    <hr />
-    <div class="row u-sv3" style="padding-top: 0.5rem;">
+<section class="p-strip--accent is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
       <div class="col-4 col-medium-2">
-        <h3 class="p-heading--5">Ubuntu typefaces</h3>
+        <h1 class="p-heading--2">Design resources</h1>
       </div>
-      <div class="col-4 u-hide--medium u-hide--small">
+      <div class="col-6 col-medium-4">
+        <p>
+          On this page you will find everything you need to design and build with our design system, including our Figma component library, our icon library and the Ubuntu font.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <div class="col-3 col-medium-2">
+          <h2>Design system library</h2>
+        </div>
+        <div class="col-1 u-hide--medium u-hide--small"></div>
+      </div>
+      <div class="col-6 col-medium-4">
+        <p>
+          In this Figma library you will find our most up-to-date responsive components to build your designs.
+        </p>
+        <p>
+          <a
+            href="https://www.figma.com/file/H6MSsN3taoXXOJCPUbIImQ/Design-System-Library?node-id=803%3A9310&t=W0OglotYBvqZyM1e-1"
+          >
+            View our Figma library
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+<div class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <h2>Brand resources</h2>
+      <hr />
+      <div class="row u-sv3" style="padding-top: 0.5rem;">
+        <div class="col-4 col-medium-2">
+          <h3 class="p-heading--5">Ubuntu typefaces</h3>
+        </div>
+        <div class="col-4 u-hide--medium u-hide--small">
+          <div
+            class="resources__content-thumb typeface"
+          >
+            {{ image (
+              url="https://assets.ubuntu.com/v1/bfe86ea2-ssh_.png",
+              alt="ssh_ written with Ubuntu typeface",
+              width="290",
+              height="129",
+              hi_def=True,
+              loading="auto|lazy"
+              ) | safe
+            }}
+          </div>
+        </div>
+        <div class="col-4 col-medium-4">
+          <p>
+            The Ubuntu font has contemporary style that conveys a precise, reliable and free attitude.
+          </p>
+          <p>
+            <a>Download the Ubuntu typefaces</a>
+          </p>
+        </div>
+      </div>
+      <hr class="u-no-margin--top" />
+      <div class="row u-sv3">
+        <div class="col-4 col-medium-2">
+          <h3 class="p-heading--5">Icon set</h3>
+        </div>
         <div
-          class="resources__content-thumb typeface"
+          class="col-4 u-hide--medium u-hide--small resources__content-thumb icons_thumb"
+          id="icon_content_thumb"
+        >
+          {% for item in resources_data.icons %}
+            <div  class="icon__item">
+              <i 
+                class="p-icon--{{ item.name }}" 
+                style="width: 18px; height: 18px;"
+              ></i>
+            </div>
+          {% endfor %}
+        </div>
+        <div class="col-4 col-medium-4">
+          <label class="p-switch">
+            <input 
+              type="checkbox" 
+              class="p-switch__input" 
+              role="switch" 
+              id="icon_switch" 
+              onchange="switchIconThumbTheme()"
+            >
+            <span class="p-switch__slider"></span>
+            <span class="p-switch__label">Dark mode</span>
+          </label>
+          <p>
+            Our icon library includes our generic UI iconography as well as some bespoke concepts.
+          </p>
+          <p>
+            <a href="https://vanillaframework.io/docs/patterns/icons">Download the icon set</a>
+          </p>
+        </div>
+      </div>
+      <hr class="u-no-margin--top" />
+      <div class="row u-sv3">
+        <div class="col-4 col-medium-2">
+          <h3 class="p-heading--5">Slide template</h3>
+        </div>
+        <div
+          class="col-4 u-hide--medium u-hide--small resources__content-thumb"
         >
           {{ image (
-            url="https://assets.ubuntu.com/v1/bfe86ea2-ssh_.png",
-            alt="ssh_ written with Ubuntu typeface",
-            width="290",
-            height="129",
+            url="https://assets.ubuntu.com/v1/47afbf87-black.png",
+            alt="black placeholder image",
+            width="400",
+            height="183",
             hi_def=True,
             loading="auto|lazy"
             ) | safe
           }}
         </div>
-      </div>
-      <div class="col-4 col-medium-4">
-        <p>
-          The Ubuntu font has contemporary style that conveys a precise, reliable and free attitude.
-        </p>
-        <p>
-          <a>Download the Ubuntu typefaces</a>
-        </p>
-      </div>
-    </div>
-    <hr class="u-no-margin--top" />
-    <div class="row u-sv3">
-      <div class="col-4 col-medium-2">
-        <h3 class="p-heading--5">Icon set</h3>
-      </div>
-      <div
-        class="col-4 u-hide--medium u-hide--small resources__content-thumb icons_thumb"
-        id="icon_content_thumb"
-      >
-        {% for item in resources_data.icons %}
-          <div  class="icon__item">
-            <i 
-              class="p-icon--{{ item.name }}" 
-              style="width: 18px; height: 18px;"
-            ></i>
-          </div>
-        {% endfor %}
-      </div>
-      <div class="col-4 col-medium-4">
-        <label class="p-switch">
-          <input 
-            type="checkbox" 
-            class="p-switch__input" 
-            role="switch" 
-            id="icon_switch" 
-            onchange="switchIconThumbTheme()"
-          >
-          <span class="p-switch__slider"></span>
-          <span class="p-switch__label">Dark mode</span>
-        </label>
-        <p>
-          Our icon library includes our generic UI iconography as well as some bespoke concepts.
-        </p>
-        <p>
-          <a href="https://vanillaframework.io/docs/patterns/icons">Download the icon set</a>
-        </p>
-      </div>
-    </div>
-    <hr class="u-no-margin--top" />
-    <div class="row u-sv3">
-      <div class="col-4 col-medium-2">
-        <h3 class="p-heading--5">Slide template</h3>
-      </div>
-      <div
-        class="col-4 u-hide--medium u-hide--small resources__content-thumb"
-      >
-        {{ image (
-          url="https://assets.ubuntu.com/v1/47afbf87-black.png",
-          alt="black placeholder image",
-          width="400",
-          height="183",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-        }}
-      </div>
-      <div class="col-4 col-medium-4">
-        <p>
-          Use this template to create presentations with the Canonical branding style.
-        </p>
-        <p>
-          <a>Download the slide template</a>
-        </p>
-      </div>
-    </div>
-    <hr class="u-no-margin--top" />
-    <div class="row">
-      <div class="col-4 col-medium-2">
-        <h3 class="p-heading--5">Logos</h3>
-      </div>
-      <div class="col-8 col-medium-4 u-sv3 resources__content-thumb logo_thumb">
-        <div class="row">
-          <div class="col-2 col-medium-2">
-            <label class="p-switch">
-              <input 
-                type="checkbox" 
-                class="p-switch__input" 
-                role="switch" id="logo_switch" 
-                onchange="switchLogoThumbTheme()"
-              >
-              <span class="p-switch__slider"></span>
-              <span class="p-switch__label">Dark mode</span>
-            </label>
-          </div>
+        <div class="col-4 col-medium-4">
+          <p>
+            Use this template to create presentations with the Canonical branding style.
+          </p>
+          <p>
+            <a>Download the slide template</a>
+          </p>
         </div>
-        <div class="col-8 u-no-margin--bottom resources__content-thumb" id="logo_content_thumb">
-          {% for item in resources_data.logos %}
-              <div class="col-8 col-medium-4 p-list__item light_strip">
-                <a href="{{ item.svg_link_light }}" target="_blank">
-                  {{ image (
-                    url=item.svg_link_light,
-                    alt=item.name,
-                    width=item.image_width,
-                    hi_def=True,
-                    loading="auto|lazy"
-                    ) | safe
-                  }}
-                </a>
-              </div>
-              <div class="col-8 col-medium-4 p-list__item resources__dark_mode dark_strip u-hide">
-                <a href="{{ item.svg_link_dark }}" target="_blank">
-                  {{ image (
-                    url=item.svg_link_dark,
-                    alt=item.name,
-                    width=item.image_width,
-                    hi_def=True,
-                    loading="auto|lazy"
-                    ) | safe
-                  }}
-                </a>
-              </div>
-              {% if loop.index < resources_data.logos|length %}
-                  <hr class="u-no-margin--top logo_separator" />
-              {% endif %} 
-          {% endfor %}
+      </div>
+      <hr class="u-no-margin--top" />
+      <div class="row">
+        <div class="col-4 col-medium-2">
+          <h3 class="p-heading--5">Logos</h3>
         </div>
-        <p>
-          <a 
-            href="https://drive.google.com/drive/u/2/folders/10CISCFXzMjn5e8hDBwH7xdPceIzIEAhS" 
-            target="_blank"
-            rel="noopener noreferrer" 
-          >
-            See all logos
-          </a>
-        </p>
+        <div class="col-8 col-medium-4 u-sv3 resources__content-thumb logo_thumb">
+          <div class="row">
+            <div class="col-2 col-medium-2">
+              <label class="p-switch">
+                <input 
+                  type="checkbox" 
+                  class="p-switch__input" 
+                  role="switch" id="logo_switch" 
+                  onchange="switchLogoThumbTheme()"
+                >
+                <span class="p-switch__slider"></span>
+                <span class="p-switch__label">Dark mode</span>
+              </label>
+            </div>
+          </div>
+          <div class="col-8 u-no-margin--bottom resources__content-thumb" id="logo_content_thumb">
+            {% for item in resources_data.logos %}
+                <div class="col-8 col-medium-4 p-list__item light_strip">
+                  <a href="{{ item.svg_link_light }}" target="_blank">
+                    {{ image (
+                      url=item.svg_link_light,
+                      alt=item.name,
+                      width=item.image_width,
+                      hi_def=True,
+                      loading="auto|lazy"
+                      ) | safe
+                    }}
+                  </a>
+                </div>
+                <div class="col-8 col-medium-4 p-list__item resources__dark_mode dark_strip u-hide">
+                  <a href="{{ item.svg_link_dark }}" target="_blank">
+                    {{ image (
+                      url=item.svg_link_dark,
+                      alt=item.name,
+                      width=item.image_width,
+                      hi_def=True,
+                      loading="auto|lazy"
+                      ) | safe
+                    }}
+                  </a>
+                </div>
+                {% if loop.index < resources_data.logos|length %}
+                    <hr class="u-no-margin--top logo_separator" />
+                {% endif %} 
+            {% endfor %}
+          </div>
+          <p>
+            <a 
+              href="https://drive.google.com/drive/u/2/folders/10CISCFXzMjn5e8hDBwH7xdPceIzIEAhS" 
+              target="_blank"
+              rel="noopener noreferrer" 
+            >
+              See all logos
+            </a>
+          </p>
+        </div>
       </div>
-    </div>
-    <hr class="u-no-margin--top" />
-    <div class="row">
-      <div class="col-4 col-medium-2">
-        <h3 class="p-heading--5">Illustrations</h3>
-      </div>
-      <div
-        class="col-4 u-hide--medium u-hide--small resources__content-thumb"
-      >
-        {{ image (
-          url="https://assets.ubuntu.com/v1/47afbf87-black.png",
-          alt="black placeholder image",
-          width="400",
-          height="183",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-        }}
-      </div>
-      <div class="col-4 col-medium-4">
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel
-          mi sed nibh ullamcorper maximus dictum varius ligula.
-        </p>
-        <p>
-          <a>Download the slide template</a>
-        </p>
+      <hr class="u-no-margin--top" />
+      <div class="row">
+        <div class="col-4 col-medium-2">
+          <h3 class="p-heading--5">Illustrations</h3>
+        </div>
+        <div
+          class="col-4 u-hide--medium u-hide--small resources__content-thumb"
+        >
+          {{ image (
+            url="https://assets.ubuntu.com/v1/47afbf87-black.png",
+            alt="black placeholder image",
+            width="400",
+            height="183",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </div>
+        <div class="col-4 col-medium-4">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel
+            mi sed nibh ullamcorper maximus dictum varius ligula.
+          </p>
+          <p>
+            <a>Download the slide template</a>
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -198,34 +198,6 @@ block content %}
           </p>
         </div>
       </div>
-      <hr class="u-no-margin--top" />
-      <div class="row">
-        <div class="col-4 col-medium-2">
-          <h3 class="p-heading--5">Illustrations</h3>
-        </div>
-        <div
-          class="col-4 u-hide--medium u-hide--small resources__content-thumb"
-        >
-          {{ image (
-            url="https://assets.ubuntu.com/v1/47afbf87-black.png",
-            alt="black placeholder image",
-            width="400",
-            height="183",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-          }}
-        </div>
-        <div class="col-4 col-medium-4">
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vel
-            mi sed nibh ullamcorper maximus dictum varius ligula.
-          </p>
-          <p>
-            <a>Download the slide template</a>
-          </p>
-        </div>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Use the new layout on the following pages:
  - Home
  - Accessibility
  - Contribute
  - Font
  - Resources
  - 404
- Minor fixes on the resources page
  - Remove the Illustration section
  - Make the Icon set section dark mode switch hide on medium and small screens

## QA

- Open the site and inspect the pages for the new layout
- Navigate to `/resources` 
- Check if the icon set switch hides on medium and small screens
- Check that the illustration section has been removed


## Issue / Card

- [WD-1299](https://warthogs.atlassian.net/browse/WD-1299)
- [WD-1297](https://warthogs.atlassian.net/browse/WD-1297)


[WD-1299]: https://warthogs.atlassian.net/browse/WD-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-1297]: https://warthogs.atlassian.net/browse/WD-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ