### PR TITLE
Remove internal google drive link

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -188,15 +188,6 @@ block content %}
                 {% endif %}
             {% endfor %}
           </div>
-          <p>
-            <a
-              href="https://drive.google.com/drive/u/2/folders/10CISCFXzMjn5e8hDBwH7xdPceIzIEAhS"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              See all logos (internal)
-            </a>
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

Removes link to internal google drive with logos.

## QA

Go to [Resources](https://design-ubuntu-com-282.demos.haus/resources) page. There should be no link below logos to google drive.