### PR TITLE
Add a page title to the brand page

### DIFF
--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -1,7 +1,8 @@
 {% extends "_layouts/page.html" %}
 
-{% block content %}
+{% block title %}Our brand values{% endblock %}
 
+{% block content %}
 <div class="p-strip--accent l-full-width">
   <div class="l-main">
     <div class="row">


### PR DESCRIPTION
## Done
- Add a page title to the brand page

## QA
1. Open the demo and click "Brand" in the navigation
2. See that the tab title is "Our brand values" which is better than live.
