### PR TITLE
Update logos on resources page to new stacked ones

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# ignore html files in docs not to mess up with template formatting
+templates/**/*.html
+build
+*.min.*
+.github
+.venv
+.dotrun.json

--- a/_data/resources.yaml
+++ b/_data/resources.yaml
@@ -1,53 +1,53 @@
-- svg_link_light: https://assets.ubuntu.com/v1/2af4a08e-Canonical+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/d76935e9-Canonical+white+text.svg
-  image_width: 102
+- svg_link_light: https://assets.ubuntu.com/v1/563c0d9b-Canonical.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg
+  image_width: 105
   image_height: 30
   name: Canonical Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/43ef5c89-Canonical+Ubuntu+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/b4f695ea-Canonical+Ubuntu+white+text.svg
-  image_width: 165
+- svg_link_light: https://assets.ubuntu.com/v1/a7e3c509-Canonical%20Ubuntu.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/594d0a0c-Canonical%20Ubuntu%20Dark.svg
+  image_width: 84
   image_height: 30
   name: Canonical Ubuntu Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/97d996a2-Canonical+Snapcraft+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/6f9b37e9-Canonical+Snapcraft+white+text.svg
-  image_width: 184
+- svg_link_light: https://assets.ubuntu.com/v1/10140ab8-Canonical%20Snapcraft.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/6b7b9995-Canonical%20Snapcraft%20Dark.svg
+  image_width: 109
   image_height: 30
   name: Canonical Snapcraft Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/bfd2d859-Canonical+Anbox+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/423606cc-Canonical+Anbox+white+text.svg
-  image_width: 158
+- svg_link_light: https://assets.ubuntu.com/v1/50cd3f20-Canonical%20Anbox.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/c65cea90-Canonical%20Anbox%20Dark.svg
+  image_width: 79
   image_height: 30
   name: Canonical Anbox Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/7964e36d-Canonical+MAAS+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/35df1d67-Canonical+MAAS+white+text.svg
-  image_width: 154
+- svg_link_light: https://assets.ubuntu.com/v1/e45b7f3f-Canonical%20MAAS.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/2eee4c1c-Canonical%20MAAS%20Dark.svg
+  image_width: 75
   image_height: 30
   name: Canonical MAAS Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/ea7adcf4-Canonical+Landscape+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/71b9a7d2-Canonical+Landscape+white+text.svg
-  image_width: 192
+- svg_link_light: https://assets.ubuntu.com/v1/7a3e288d-Canonical%20Landscape.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/1f81cf02-Canonical%20Landscape%20Dark.svg
+  image_width: 115
   image_height: 30
   name: Canonical Landscape Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/6405175c-Canonical+Juju+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/7a094830-Canonical+Juju+white+text.svg
-  image_width: 139
+- svg_link_light: https://assets.ubuntu.com/v1/e3a315b9-Canonical%20Juju.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/8c0eb2cb-Canonical%20Juju%20Dark.svg
+  image_width: 138
   image_height: 30
   name: Canonical Juju Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/2cdf1c98-Canonical+OpenStack+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/1a3e220b-Canonical+OpenStack+white+text.svg
-  image_width: 192
+- svg_link_light: https://assets.ubuntu.com/v1/f07eaf0c-Canonical%20OpenStack.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/8232828d-Canonical%20OpenStack%20Dark.svg
+  image_width: 118
   image_height: 30
   name: Canonical Openstack Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/805a3cab-Canonical+Kubernetes+dark+text.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/b4b28be3-Canonical+Kubernetes+white+text.svg
-  image_width: 200
+- svg_link_light: https://assets.ubuntu.com/v1/e5279b88-Canonical%20Kubernetes.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/4bbaebaa-Canonical%20Kubernetes%20Dark.svg
+  image_width: 119
   image_height: 30
   name: Canonical Kubernetes Logo

--- a/_data/resources.yaml
+++ b/_data/resources.yaml
@@ -1,53 +1,35 @@
 - svg_link_light: https://assets.ubuntu.com/v1/563c0d9b-Canonical.svg
   svg_link_dark: https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg
-  image_width: 105
-  image_height: 30
   name: Canonical Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/a7e3c509-Canonical%20Ubuntu.svg
   svg_link_dark: https://assets.ubuntu.com/v1/594d0a0c-Canonical%20Ubuntu%20Dark.svg
-  image_width: 84
-  image_height: 30
   name: Canonical Ubuntu Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/10140ab8-Canonical%20Snapcraft.svg
   svg_link_dark: https://assets.ubuntu.com/v1/6b7b9995-Canonical%20Snapcraft%20Dark.svg
-  image_width: 109
-  image_height: 30
   name: Canonical Snapcraft Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/50cd3f20-Canonical%20Anbox.svg
   svg_link_dark: https://assets.ubuntu.com/v1/c65cea90-Canonical%20Anbox%20Dark.svg
-  image_width: 79
-  image_height: 30
   name: Canonical Anbox Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/e45b7f3f-Canonical%20MAAS.svg
   svg_link_dark: https://assets.ubuntu.com/v1/2eee4c1c-Canonical%20MAAS%20Dark.svg
-  image_width: 75
-  image_height: 30
   name: Canonical MAAS Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/7a3e288d-Canonical%20Landscape.svg
   svg_link_dark: https://assets.ubuntu.com/v1/1f81cf02-Canonical%20Landscape%20Dark.svg
-  image_width: 115
-  image_height: 30
   name: Canonical Landscape Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/16a67f91-Canonical%20Juju.svg
   svg_link_dark: https://assets.ubuntu.com/v1/3998e1b9-Canonical%20Juju%20Dark.svg
-  image_width: 57
-  image_height: 30
   name: Canonical Juju Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/f07eaf0c-Canonical%20OpenStack.svg
   svg_link_dark: https://assets.ubuntu.com/v1/8232828d-Canonical%20OpenStack%20Dark.svg
-  image_width: 118
-  image_height: 30
   name: Canonical Openstack Logo
 
 - svg_link_light: https://assets.ubuntu.com/v1/e5279b88-Canonical%20Kubernetes.svg
   svg_link_dark: https://assets.ubuntu.com/v1/4bbaebaa-Canonical%20Kubernetes%20Dark.svg
-  image_width: 119
-  image_height: 30
   name: Canonical Kubernetes Logo

--- a/_data/resources.yaml
+++ b/_data/resources.yaml
@@ -34,9 +34,9 @@
   image_height: 30
   name: Canonical Landscape Logo
 
-- svg_link_light: https://assets.ubuntu.com/v1/e3a315b9-Canonical%20Juju.svg
-  svg_link_dark: https://assets.ubuntu.com/v1/8c0eb2cb-Canonical%20Juju%20Dark.svg
-  image_width: 138
+- svg_link_light: https://assets.ubuntu.com/v1/16a67f91-Canonical%20Juju.svg
+  svg_link_dark: https://assets.ubuntu.com/v1/3998e1b9-Canonical%20Juju%20Dark.svg
+  image_width: 57
   image_height: 30
   name: Canonical Juju Logo
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -102,3 +102,9 @@ $font-allow-cyrillic-greek-latin: true;
   background-color: $color-brand !important;
   color: $color-x-light;
 }
+
+.resources_logo {
+  /* remove rounded corners from images to avoid distorting logos */
+  border-radius: 0;
+  height: 3rem;
+}

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -23,11 +23,6 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-NV2KV6F');</script>
   <!-- End Google Tag Manager -->
-
-  <style>
-    /* remove rounded corners from images to avoid distorting logos */
-    img { border-radius: 0; }
-  </style>
 </head>
 
 

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -23,6 +23,11 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-NV2KV6F');</script>
   <!-- End Google Tag Manager -->
+
+  <style>
+    /* remove rounded corners from images to avoid distorting logos */
+    img { border-radius: 0; }
+  </style>
 </head>
 
 

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -163,12 +163,12 @@
             {% for item in resources_data.logos %}
                 <div class="col-8 col-medium-4 p-list__item light_strip">
                   <a href="{{ item.svg_link_light }}" target="_blank">
-                    <img src="{{ item.svg_link_light }}" alt="{{ item.name }}" height="{{ item.image_height }}" width="{{ item.image_width }}" />
+                    <img class="resources_logo" src="{{ item.svg_link_light }}" alt="{{ item.name }}" />
                   </a>
                 </div>
                 <div class="col-8 col-medium-4 p-list__item resources__dark_mode dark_strip u-hide">
                   <a href="{{ item.svg_link_dark }}" target="_blank">
-                    <img src="{{ item.svg_link_dark }}" alt="{{ item.name }}" height="{{ item.image_height }}" width="{{ item.image_width }}" />
+                    <img class="resources_logo" src="{{ item.svg_link_dark }}" alt="{{ item.name }}" />
                   </a>
                 </div>
                 {% if loop.index < resources_data.logos|length %}

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -163,28 +163,12 @@
             {% for item in resources_data.logos %}
                 <div class="col-8 col-medium-4 p-list__item light_strip">
                   <a href="{{ item.svg_link_light }}" target="_blank">
-                    {{ image (
-                      url=item.svg_link_light,
-                      alt=item.name,
-                      height=item.image_height,
-                      width=item.image_width,
-                      hi_def=True,
-                      loading="auto|lazy"
-                      ) | safe
-                    }}
+                    <img src="{{ item.svg_link_light }}" alt="{{ item.name }}" height="{{ item.image_height }}" width="{{ item.image_width }}" />
                   </a>
                 </div>
                 <div class="col-8 col-medium-4 p-list__item resources__dark_mode dark_strip u-hide">
                   <a href="{{ item.svg_link_dark }}" target="_blank">
-                    {{ image (
-                      url=item.svg_link_dark,
-                      alt=item.name,
-                      height=item.image_height,
-                      width=item.image_width,
-                      hi_def=True,
-                      loading="auto|lazy"
-                      ) | safe
-                    }}
+                    <img src="{{ item.svg_link_dark }}" alt="{{ item.name }}" height="{{ item.image_height }}" width="{{ item.image_width }}" />
                   </a>
                 </div>
                 {% if loop.index < resources_data.logos|length %}

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -1,5 +1,7 @@
-{% extends "_layouts/page-bare.html" %} {% block title %}Resources{% endblock %} {%
-block content %}
+{% extends "_layouts/page-bare.html" %}
+{% block title %}Resources{% endblock %}
+
+{% block content %}
 <section class="p-strip--accent is-deep l-full-width">
   <div class="l-main">
     <div class="row">
@@ -164,6 +166,7 @@ block content %}
                     {{ image (
                       url=item.svg_link_light,
                       alt=item.name,
+                      height=item.image_height,
                       width=item.image_width,
                       hi_def=True,
                       loading="auto|lazy"
@@ -176,6 +179,7 @@ block content %}
                     {{ image (
                       url=item.svg_link_dark,
                       alt=item.name,
+                      height=item.image_height,
                       width=item.image_width,
                       hi_def=True,
                       loading="auto|lazy"


### PR DESCRIPTION
## Done

Updated logos on resources page with new stacked ones.

Fixes WD-3039


## QA

- Go to resources page: https://design-ubuntu-com-287.demos.haus/resources
  - make sure logos are updated to new versions
 
![logos](https://user-images.githubusercontent.com/83575/230619161-beafabbd-8e92-49f2-8294-95acc3ccb307.gif)