### PR TITLE
Use versioned links to static resources

### DIFF
--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -9,7 +9,7 @@
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />
 
-  <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('static/css/main.css') }}" />
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/main.css') }}" />
 
   <title>{% block title %}{{ title }}{% endblock title %}</title>
   <meta name="description" content="Ubuntu brand, app and web guidelines that help you create professional materials, software, sites, apps that build the Ubuntu brand.">
@@ -119,8 +119,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 
 <!-- cookie policy and gloabl navigation component -->
-<script src="{{ versioned_static('static/js/cookie-policy.js') }}"></script>
-<script src="{{ versioned_static('static/js/global-nav.js') }}"></script>
+<script src="{{ versioned_static('js/cookie-policy.js') }}"></script>
+<script src="{{ versioned_static('js/global-nav.js') }}"></script>
 <script>
   canonicalGlobalNav.createNav();
   cpNs.cookiePolicy();

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -9,7 +9,7 @@
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />
 
-  <link rel="stylesheet" type="text/css" media="screen" href="/static/css/main.css" />
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('static/css/main.css') }}" />
 
   <title>{% block title %}{{ title }}{% endblock title %}</title>
   <meta name="description" content="Ubuntu brand, app and web guidelines that help you create professional materials, software, sites, apps that build the Ubuntu brand.">
@@ -119,8 +119,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 
 <!-- cookie policy and gloabl navigation component -->
-<script src="/static/js/cookie-policy.js"></script>
-<script src="/static/js/global-nav.js"></script>
+<script src="{{ versioned_static('static/js/cookie-policy.js') }}"></script>
+<script src="{{ versioned_static('static/js/global-nav.js') }}"></script>
 <script>
   canonicalGlobalNav.createNav();
   cpNs.cookiePolicy();

--- a/templates/font/index.html
+++ b/templates/font/index.html
@@ -217,5 +217,5 @@ Greek sample:
     </div>
   </div>
 </section>
-<script src="/static/js/font.js"></script>
+<script src="{{ versioned_static('js/font.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done

Makes sure all static resources are versioned to avoid cache issues.

## QA

- Go to demo, make sure it displays correctly (https://design-ubuntu-com-288.demos.haus/)
- Inspect the page, make sure static resources use versioned URLs

