### PR TITLE
Add wallpaper section to Resources page

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -115,6 +115,33 @@
       <hr class="u-no-margin--top" />
       <div class="row u-sv3">
         <div class="col-4 col-medium-2">
+          <h3 class="p-heading--5">Wallpapers</h3>
+        </div>
+        <div
+          class="col-4 u-hide--medium u-hide--small"
+        >
+          {{ image (
+            url="https://assets.ubuntu.com/v1/5d68f7aa-ubuntu-lunar-wallpaper-thumbnail.png",
+            alt="",
+            width="1500",
+            height="845",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </div>
+        <div class="col-4 col-medium-4">
+          <p>
+            Ubuntu wallpapers and the mascot are important parts of our brand identity.
+          </p>
+          <p>
+            <a href="https://drive.google.com/drive/folders/13WUQ5vMI625XOGVLtKMBFuif8sdFTxmN?usp=drive_link">Browse the 23.04 Lunar Lobster wallpapers</a>
+          </p>
+        </div>
+      </div>
+      <hr class="u-no-margin--top" />
+      <div class="row u-sv3">
+        <div class="col-4 col-medium-2">
           <h3 class="p-heading--5">Slide template</h3>
         </div>
         <div


### PR DESCRIPTION
## Done

Fixes [WD-5433](https://warthogs.atlassian.net/browse/WD-5433)

## QA

- Go to [Resources page](https://design-ubuntu-com-294.demos.haus/resources)
- Make sure Wallpaper section is there
- Make sure link to wallpapers folder works (and is public)

## Screenshots

<img width="1286" alt="image" src="https://github.com/canonical/design.ubuntu.com/assets/83575/5b134db5-f407-4ff5-8f19-7a854c7cc5ba">


[WD-5433]: https://warthogs.atlassian.net/browse/WD-5433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ