### PR TITLE
Update resource's dark mode's background

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -99,7 +99,7 @@ $font-allow-cyrillic-greek-latin: true;
 }
 
 .resources__dark_mode {
-  background-color: $color-brand !important;
+  background-color: $color-dark !important;
   color: $color-x-light;
 }
 


### PR DESCRIPTION
## Done

Fix dark mode's background

## QA

Go to /resources and enable dark mode

## Issue / Card
https://warthogs.atlassian.net/browse/WD-6233

## Screenshots

![image](https://github.com/canonical/design.ubuntu.com/assets/11927929/e849c199-fb7d-4050-bca8-0ef26f597597)

