### PR TITLE
Ignore warnings to prevent failing build

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install node dependencies
         run: yarn install --immutable
       - name: Install python dependencies
-        run: | 
+        run: |
           python3 -m pip install --upgrade pip
           sudo pip3 install flake8==3.7.9 black
       - name: Lint python
@@ -52,7 +52,7 @@ jobs:
       - name: Install linkchecker
         run: sudo pip install LinkChecker
       - name: Check internal links
-        run: linkchecker --ignore-url  e_sharpen --ignore-url  w_[0-9]* --ignore-url  h_[0-9]* http://localhost
+        run: linkchecker --no-warnings --ignore-url  e_sharpen --ignore-url  w_[0-9]* --ignore-url  h_[0-9]* http://localhost
 
   check-inclusive-naming:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Done

Version 10.3 of linkchecker throws warnings on redirects and fails the build (https://linkchecker.github.io/linkchecker/upgrading.html#migrating-from-10-2-to-10-3).

This PR ignores linkchecker redirect warnings to prevent them from failing the CI.

## QA

- make sure linkchecker CI job passes

