### PR TITLE
Add email signature to design resources

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -109,3 +109,9 @@ $breakpoint-navigation-threshold: 1110px;
   border-radius: 0;
   height: 3rem;
 }
+
+.email-signature-frame {
+  background-color: white;
+  display: block;
+  width: 100%;
+}

--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -1,0 +1,89 @@
+<div style="font-family: Ubuntu,sans-serif; margin:0px;">
+  <table
+    style="border-spacing:0px; border-width:0px; font-family: Ubuntu, sans-serif;margin:0px;color: #000; border-color:white;">
+    <tbody>
+      <tr>
+        <th
+          style="vertical-align:top;padding:0px;font-size: 0px; text-align: left;padding-top: 4px;padding-left: 4px;"
+          colspan="2">
+          <img height="39px" width="195.5px" style="margin-bottom: 17px;"
+            src="https://assets.ubuntu.com/v1/d47bb5aa-image3.png" alt="Canonical-20th-anniversary"
+            title="Canonical-20th-anniversary">
+        </th>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;padding:0px; padding-left:5px; font-size: 0px;" colspan="2">
+          <p
+            style="display:inline-block;font-size:13px;line-height:16px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;font-weight:600;">
+            Hadley Carlisle</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;padding:0px; padding-left:5px;font-size: 0px;" colspan="2">
+          <p
+            style="display:inline-block;font-size:13px;line-height:16px;padding-top:0.8px;margin-bottom: 8px;margin-top:0.8px; color:#757575; font-weight:500;">
+            Visual Designer</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top; padding:0px; padding-left:5px; font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;color:#757575;font-weight:500;">
+            Email: </p>
+        </td>
+        <td style="vertical-align:top; padding:0px; padding-left:5px;padding-right:4px;font-size: 0px;">
+          <a href="#"
+            style="color:#000000;text-decoration: none;">
+            <p
+              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px;margin-top:0.8px;margin-left: 12px;font-weight:500;">
+              hadley.carlisle@canonical.com</p>
+          </a>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;color:#757575; font-weight:500;">
+            Location:</p>
+        </td>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;;margin-top:0.8px;margin-left: 12px; font-weight:500;">
+            United Kingdom</p>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px; margin-top:0.8px;color:#757575; font-weight:500;">
+            Mobile:</p>
+        </td>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px; margin-top:0.8px;margin-left: 12px; font-weight:500;">
+            +1 2345 6789</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;" colspan="2">
+          <a href="https://canonical.com/" style="color:#0066cc;text-decoration: none;">
+            <p
+              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:8.8px; font-weight:500;">
+              canonical.com</p>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;" colspan="2">
+          <a href="https://ubuntu.com/" style="color:#0066cc;text-decoration: none;">
+            <p
+              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px; font-weight:500;">
+              ubuntu.com</p>
+          </a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -6,8 +6,8 @@
         <th
           style="vertical-align:top;padding:0px;font-size: 0px; text-align: left;padding-top: 4px;padding-left: 4px;"
           colspan="2">
-          <img height="39px" width="195.5px" style="margin-bottom: 17px;"
-            src="https://assets.ubuntu.com/v1/d47bb5aa-image3.png" alt="Canonical-20th-anniversary"
+          <img height="40px" width="271px" style="margin-bottom: 17px;"
+            src="https://assets.ubuntu.com/v1/e3fc2c4f-20%20YEARS_logo_white-bg.png" alt="Canonical-20th-anniversary"
             title="Canonical-20th-anniversary">
         </th>
       </tr>

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -219,53 +219,17 @@
         <iframe class="email-signature-frame" id="email-signature-frame" height="250px">
         </iframe>
       </div>
-      <button id="email-signature-copy-button" class="p-button--positive u-no-margin--right u-float-right has-icon"><i class="js-copy-icon p-icon--copy is-dark"></i><span id="copy-button-label">Copy to clipboard</span></button>
       <template id="email-signature-template">{% include "resources/_email-signature.html" %}</template>
       <script>
         if ("content" in document.createElement("template")) {
           const frame = document.querySelector("#email-signature-frame");
           const template = document.querySelector("#email-signature-template");
-          const button = document.querySelector("#email-signature-copy-button");
 
           const doc = frame.contentWindow.document;
           doc.open();
           doc.write(template.innerHTML);
           doc.close();
           doc.body.contentEditable = true;
-
-          // based on
-          // https://stackoverflow.com/questions/23934656/how-can-i-copy-rich-text-contents-to-the-clipboard-with-javascript
-          function copyHtmlToClip(str) {
-            function handleCopy(e) {
-              e.clipboardData.setData("text/html", str);
-              e.clipboardData.setData("text/plain", str);
-              e.preventDefault();
-            }
-            document.addEventListener("copy", handleCopy);
-            document.execCommand("copy");
-            document.removeEventListener("copy", handleCopy);
-          };
-
-          button.addEventListener("click", function() {
-            copyHtmlToClip(doc.body.innerHTML);
-
-            const buttonRect = button.getBoundingClientRect();
-            button.style.width = buttonRect.width + 'px';
-            button.style.height = buttonRect.height + 'px';
-
-            button.querySelector(".js-copy-icon").classList.add("p-icon--success");
-            button.querySelector(".js-copy-icon").classList.remove("p-icon--copy");
-            button.querySelector("#copy-button-label").textContent = "Copied!";
-
-            setTimeout(() => {
-              button.style.width = "";
-              button.style.height = "";
-
-              button.querySelector(".js-copy-icon").classList.remove("p-icon--success");
-              button.querySelector(".js-copy-icon").classList.add("p-icon--copy");
-              button.querySelector("#copy-button-label").textContent = "Copy to clipboard";
-            }, 2000);
-          });
         }
       </script>
     </div>

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -151,10 +151,10 @@
     <div class="col">
       <div class="p-media-container">
         {{ image (
-          url="https://assets.ubuntu.com/v1/59e3bb07-Slide_template.png",
+          url="https://assets.ubuntu.com/v1/b28a9bc4-slide-deck-preview.png",
           alt="",
-          width="780",
-          height="440",
+          width="802",
+          height="451",
           hi_def=True,
           loading="auto|lazy"
           ) | safe

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -207,6 +207,69 @@
       </div>
     </div>
   </div>
+
+  <!-- EMAIL SIGNATURE -->
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h3 class="p-heading--2" id="logos">Email signature</h3>
+    </div>
+    <div class="col">
+      <div class="p-media-container">
+        <iframe class="email-signature-frame" id="email-signature-frame" height="250px">
+        </iframe>
+      </div>
+      <button id="email-signature-copy-button" class="p-button--positive u-no-margin--right u-float-right has-icon"><i class="js-copy-icon p-icon--copy is-dark"></i><span id="copy-button-label">Copy to clipboard</span></button>
+      <template id="email-signature-template">{% include "resources/_email-signature.html" %}</template>
+      <script>
+        if ("content" in document.createElement("template")) {
+          const frame = document.querySelector("#email-signature-frame");
+          const template = document.querySelector("#email-signature-template");
+          const button = document.querySelector("#email-signature-copy-button");
+
+          const doc = frame.contentWindow.document;
+          doc.open();
+          doc.write(template.innerHTML);
+          doc.close();
+          doc.body.contentEditable = true;
+
+          // based on
+          // https://stackoverflow.com/questions/23934656/how-can-i-copy-rich-text-contents-to-the-clipboard-with-javascript
+          function copyHtmlToClip(str) {
+            function handleCopy(e) {
+              e.clipboardData.setData("text/html", str);
+              e.clipboardData.setData("text/plain", str);
+              e.preventDefault();
+            }
+            document.addEventListener("copy", handleCopy);
+            document.execCommand("copy");
+            document.removeEventListener("copy", handleCopy);
+          };
+
+          button.addEventListener("click", function() {
+            copyHtmlToClip(doc.body.innerHTML);
+
+            const buttonRect = button.getBoundingClientRect();
+            button.style.width = buttonRect.width + 'px';
+            button.style.height = buttonRect.height + 'px';
+
+            button.querySelector(".js-copy-icon").classList.add("p-icon--success");
+            button.querySelector(".js-copy-icon").classList.remove("p-icon--copy");
+            button.querySelector("#copy-button-label").textContent = "Copied!";
+
+            setTimeout(() => {
+              button.style.width = "";
+              button.style.height = "";
+
+              button.querySelector(".js-copy-icon").classList.remove("p-icon--success");
+              button.querySelector(".js-copy-icon").classList.add("p-icon--copy");
+              button.querySelector("#copy-button-label").textContent = "Copy to clipboard";
+            }, 2000);
+          });
+        }
+      </script>
+    </div>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Done

Adds email signature to design resources.

Drive-by: update slide template preview

Fixes [WD-9907](https://warthogs.atlassian.net/browse/WD-9907)
Fixes [WD-4140](https://warthogs.atlassian.net/browse/WD-4140)

## QA

- Go do [resources page](https://design-ubuntu-com-311.demos.haus/resources), scroll down to email signature
- Edit details in place if you want to
- Select the signature and copy it
- Go to Gmail
  - compose new email, paste signature into the email
  - or go to Gmail / Settings / Signature and paste it as a signature


## Screenshots

<img width="1268" alt="image" src="https://github.com/canonical/design.ubuntu.com/assets/83575/0b5e883f-82bd-4407-9ddd-b54302771768">




[WD-9907]: https://warthogs.atlassian.net/browse/WD-9907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-4140]: https://warthogs.atlassian.net/browse/WD-4140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ