### PR TITLE
Remove unnecessary link from email signature template

### DIFF
--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -32,12 +32,9 @@
             Email: </p>
         </td>
         <td style="vertical-align:top; padding:0px; padding-left:5px;padding-right:4px;font-size: 0px;">
-          <a href="#"
-            style="color:#000000;text-decoration: none;">
             <p
               style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px;margin-top:0.8px;margin-left: 12px;font-weight:500;">
               hadley.carlisle@canonical.com</p>
-          </a>
         </td>
       </tr>
 


### PR DESCRIPTION
## Done

Removed unnecessary empty link from email signature template

## QA

- https://design-ubuntu-com-312.demos.haus/resources
- Check if email signature renders fine without the link around email address
