### PR TITLE
Fix the id of email signature section on Resources page

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -212,7 +212,7 @@
   <div class="row--50-50">
     <hr class="p-rule" />
     <div class="col">
-      <h3 class="p-heading--2" id="logos">Email signature</h3>
+      <h3 class="p-heading--2" id="email-signature">Email signature</h3>
     </div>
     <div class="col">
       <div class="p-media-container">


### PR DESCRIPTION
## Done

Updates the duplicated id and replaces it with a `#email-signature` id, so that email signature section can be targeted in URL.

Fixed issue reported in https://github.com/canonical/design.ubuntu.com/pull/311#issuecomment-2025462261

## QA

Go to demo resources page using direct link to email section, make sure the page loads scrolled down:
https://design-ubuntu-com-314.demos.haus/resources#email-signature



