### PR TITLE
Remove editing from email signature

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -229,7 +229,6 @@
           doc.open();
           doc.write(template.innerHTML);
           doc.close();
-          doc.body.contentEditable = true;
         }
       </script>
     </div>


### PR DESCRIPTION
## Done

Removes editing option from email signature template, because it was confusing and too easy to mess up then trying to select (by dragging the image).

## QA

Go to: https://design-ubuntu-com-315.demos.haus/resources#email-signature
Make sure email signature can be selected but is not editable.

