### PR TITLE
Add the copydoc meta header to the site

### DIFF
--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -15,6 +15,7 @@
   <meta name="description" content="Ubuntu brand, app and web guidelines that help you create professional materials, software, sites, apps that build the Ubuntu brand.">
   <meta name="keywords" content="Ubuntu, Design, Brand guidelines, web guidelines, apps guidelines, colors, buttons, layout, styleguide" />
   <meta name="author" content="Canonical" />
+  <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/0/folders/1LxHnsplr5Xd8JQxNvwvLil2J_Q5_3loU{% endblock %}" />
 
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/templates/accessibility/index.html
+++ b/templates/accessibility/index.html
@@ -2,6 +2,9 @@
 
 {% block title %}Accessibility{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1I3_o1mfEdaA4NmT4XBpy3F-vIfraPrWv3fPYdAif1uE/edit{% endblock %}
+
+
 {% block content %}
 <div class="p-suru--50-50">
   <div class="row--50-50">

--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Our brand values{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1nyNLG5IfJHRpGGMJzJIkm3TJSXTvd4vOdMhu2M9Lfxo/edit{% endblock %}
+
 {% block content %}
 
 <div class="p-suru--25-75">

--- a/templates/contribute/index.html
+++ b/templates/contribute/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Contribute{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1az4PIbq8M3LqzU0hxyhCi7JyCulFWXDqdHHv2ycFFNo/edit{% endblock %}
+
 {% block content %}
 <section class="p-suru--50-50">
   <div class="row--50-50">

--- a/templates/font/index.html
+++ b/templates/font/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Ubuntu font{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1wFqMxSex8Ns9_bh7tbdekUnLV80CrLg9LgYmeSdXK_4/edit{% endblock %}
+
 {% block content %}
 <div class="p-suru--25-75">
   <div class="row--25-75">

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Ubuntu Design{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1gAcMzBy67q0QcS7DuQcY9PA2h6E-p5rb4RJSgH_Clm0/edit{% endblock %}
+
 {% block content %}
 <div class="p-suru--25-75">
   <div class="row--25-75">

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -1,6 +1,8 @@
 {% extends "_layouts/page-bare.html" %}
 {% block title %}Resources{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1lhk5KwzsG1kkL1p1Ge5N8x33Y7TpKL4dHjZPCFaXbs4/edit{% endblock %}
+
 {% block content %}
 <section class="p-suru--50-50">
   <div class="row--50-50">

--- a/templates/vanilla/index.html
+++ b/templates/vanilla/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}Vanilla{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1XTIt173IwzIPNYEVA0xZDkSkxSRkL7fvjLsEr1Att6w/edit{% endblock %}
+
 {% block content %}
 <section class="p-suru--25-75">
   <div class="row--25-75">


### PR DESCRIPTION
## Done
Add the copydoc meta header to the site
Add the two copydocs we have

## QA
1. Open the demo
2. Check you see the copydoc extension show up
3. Check homepage and font pages to load a copy doc
4. Other pages should open the folder