### PR TITLE
WD-11578 - fix /contribute page text

### DIFF
--- a/templates/contribute/index.html
+++ b/templates/contribute/index.html
@@ -32,7 +32,7 @@
         suggest a fix by creating a pull request.
       </p>
       <p>
-        Please provide as much information possible detailing what you're currently experiencing and what you'd expect
+        Please provide as much information as possible detailing what you're currently experiencing and what you'd expect
         to experience.
       </p>
     </div>


### PR DESCRIPTION
## Done

Update text on /contribute page

## QA

- [demo link](https://ubuntu-com-13902.demos.haus/download/desktop/thank-you?version=24.04&architecture=amd64&lts=true)
- [copy doc](https://docs.google.com/document/d/1az4PIbq8M3LqzU0hxyhCi7JyCulFWXDqdHHv2ycFFNo/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correctly updated according to copy doc

## Issue / Card
[WD-11578](https://warthogs.atlassian.net/browse/WD-11578)