### PR TITLE
Add more Vanilla links to Vanilla page

### DIFF
--- a/templates/vanilla/index.html
+++ b/templates/vanilla/index.html
@@ -11,7 +11,7 @@
       <h1>Vanilla</h1>
     </div>
     <div class="col">
-      <p>Vanilla is our lightweight, composable and open-source component library. It contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
+      <p><a href="https://vanillaframework.io">Vanilla</a> is our lightweight, composable and open-source component library. It contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
       <p>
         A simple, extensible CSS framework.<br />
         Backed by open-source and written in Sass by the Canonical Web Team.
@@ -37,7 +37,7 @@
           }}
           <h2 class="p-heading-icon__title">Lightweight</h2>
         </div>
-        <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns
+        <p><a href="https://vanillaframework.io">Vanilla</a> contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns
           and utility classes that you can extend.</p>
       </div>
     </div>
@@ -89,7 +89,7 @@
       <h2>Documentation</h2>
     </div>
     <div class="col">
-      <p>Vanilla framework documentation contains everything you need to know to download, install and use it in your projects.</p>
+      <p><a href="https://vanillaframework.io/docs">Vanilla framework documentation</a> contains everything you need to know to download, install and use it in your projects.</p>
       <p>Learn about the settings, base styles, components, utilities, layouts to build the sites or apps.</p>
       <a href="https://vanillaframework.io/docs">Read Vanilla framework documentation</a>
     </div>
@@ -103,7 +103,7 @@
       <h2>Source code</h2>
     </div>
     <div class="col">
-      <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
+      <p>Anyone can <a href="https://vanillaframework.io/contribute">contribute to Vanilla</a>, improve it and extend it. All the <a href="https://github.com/canonical/vanilla-framework/">code is available on GitHub</a> and is licensed under LGPLv3 by Canonical.</p>
       <ul class="p-list--divided">
         <li class="p-list__item"><a href="https://github.com/canonical/vanilla-framework/">Browse the source code on GitHub</a></li>
         <li class="p-list__item"><a href="https://github.com/canonical/vanilla-framework/releases/latest">Download latest release</a></li>


### PR DESCRIPTION
## Done

Adds more links to Vanilla website from Design System Vanilla page.

Fixes: https://warthogs.atlassian.net/browse/WD-12518

## QA

 - go to Vanilla page: https://design-ubuntu-com-318.demos.haus/vanilla
 - check if you find links to Vanilla home page, docs and github

