### PR TITLE
Invoke cookie policy before gtm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "watch-cli": "0.2.3"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.5.0",
+    "@canonical/cookie-policy": "^3.6.4",
     "@canonical/global-nav": "3.6.4",
     "postcss": "8.4.36",
     "vanilla-framework": "4.9.0"

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -31,6 +31,12 @@
   <meta name="author" content="Canonical" />
   <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/0/folders/1LxHnsplr5Xd8JQxNvwvLil2J_Q5_3loU{% endblock %}" />
 
+  <!-- Cookie policy -->
+  <script src="{{ versioned_static('js/cookie-policy.js') }}"></script>
+  <script>
+    cpNs.cookiePolicy();
+  </script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -125,12 +131,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </footer>
 
-<!-- cookie policy and gloabl navigation component -->
-<script src="{{ versioned_static('js/cookie-policy.js') }}"></script>
+<!-- global navigation component -->
 <script src="{{ versioned_static('js/global-nav.js') }}"></script>
 <script>
-  canonicalGlobalNav.createNav();
-  cpNs.cookiePolicy();
+  canonicalGlobalNav.createNav();  
 </script>
 
 {% if path.startswith('/font') %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@canonical/cookie-policy@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.5.0.tgz#1c7e6cc2d5a7218375001b2cff2996a927693e89"
-  integrity sha512-XLCIl8+h+3BRfvqADqFsmAfWdaDGDchY/TPCKtpeQdb4r64SR6arsdNftlOb7vX8EuLCK2QRp6evUy0J+qnQTg==
+"@canonical/cookie-policy@^3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
+  integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
 
 "@canonical/global-nav@3.6.4":
   version "3.6.4"


### PR DESCRIPTION
## Done

- Move cookie policy before GTM

## QA

- Go to demo
- Open dev tools and go to Networks tab
- Check that the cookie policy finishes its updates before GTM script invoked

## Issue / Card

Fixes [WD-15451](https://warthogs.atlassian.net/browse/WD-15451) and [WD-15825](https://warthogs.atlassian.net/browse/WD-15825)

## Screenshots

[if relevant, include a screenshot]


[WD-15451]: https://warthogs.atlassian.net/browse/WD-15451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-15825]: https://warthogs.atlassian.net/browse/WD-15825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ