### PR TITLE
Remove internal slides from the resources page

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -144,34 +144,6 @@
     </div>
   </div>
 
-  <!-- SLIDES -->
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h3 class="p-heading--2">Slide template</h3>
-    </div>
-    <div class="col">
-      <div class="p-media-container">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/b28a9bc4-slide-deck-preview.png",
-          alt="",
-          width="802",
-          height="451",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-        }}
-      </div>
-
-      <p>
-        Use this template to create presentations with the Canonical branding style.
-      </p>
-      <p>
-        <a href="https://docs.google.com/presentation/u/0/?tgif=d&ftv=1">Use the slide template (internal)</a>
-      </p>
-    </div>
-  </div>
-
   <!-- LOGOS -->
   <div class="row--50-50">
     <hr class="p-rule" />


### PR DESCRIPTION
## Done

Removes internal slides from resources page

Fixes https://warthogs.atlassian.net/browse/WD-14508

## QA

Check the [updated resources page](https://design-ubuntu-com-325.demos.haus/resources), make sure slides are not listed there anymore. (compare with [live version](https://design.ubuntu.com/resources)).
