### PR TITLE
Update Figma library link

### DIFF
--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -30,7 +30,7 @@
       </p>
       <p>
         <a
-          href="https://www.figma.com/file/H6MSsN3taoXXOJCPUbIImQ/Design-System-Library?node-id=803%3A9310&t=W0OglotYBvqZyM1e-1"
+          href="https://www.figma.com/community/file/1435297834108003391/vanilla-core-component-library"
         >
           View our Figma library
         </a>

--- a/templates/vanilla/index.html
+++ b/templates/vanilla/index.html
@@ -123,8 +123,7 @@
     <div class="col">
       <p>Alongside the Vanilla CSS framework we also provide tools to help you build your designs using our most up-to-date responsive components.</p>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://www.figma.com/file/H6MSsN3taoXXOJCPUbIImQ/Design-System-Library?node-id=803%3A9310&t=W0OglotYBvqZyM1e-1">Figma library</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Sketch UI kit</a> <small>(no longer maintained, compatible with Vanilla v2.25).</small></li>
+        <li class="p-list__item"><a href="https://www.figma.com/community/file/1435297834108003391/vanilla-core-component-library">Figma library</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done
- Updated link of Figma library to the latest link
- Removed link to Sketch library (I assumed we don't want to link to this outdated library anymore?)

## QA
- check the links work as expected
