### PR TITLE
WD-18640 - Feat: switch email signature to user standard Canonical logo and add additional fields

### DIFF
--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -6,9 +6,10 @@
         <th
           style="vertical-align:top;padding:0px;font-size: 0px; text-align: left;padding-top: 4px;padding-left: 4px;"
           colspan="2">
-          <img height="40px" width="271px" style="margin-bottom: 17px;"
-            src="https://assets.ubuntu.com/v1/e3fc2c4f-20%20YEARS_logo_white-bg.png" alt="Canonical-20th-anniversary"
-            title="Canonical-20th-anniversary">
+          <img height="40px" width="140px" style="margin-bottom: 17px;"
+            src="https://assets.ubuntu.com/v1/563c0d9b-Canonical.svg"
+            alt="Canonical Logo"
+            title="Canonical Logo">
         </th>
       </tr>
       <tr>

--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -6,8 +6,8 @@
         <th
           style="vertical-align:top;padding:0px;font-size: 0px; text-align: left;padding-top: 4px;padding-left: 4px;"
           colspan="2">
-          <img height="40px" width="140px" style="margin-bottom: 17px;"
-            src="https://assets.ubuntu.com/v1/563c0d9b-Canonical.svg"
+          <img height="40px" width="128px" style="margin-bottom: 17px;"
+            src="https://assets.ubuntu.com/v1/4677e80e-Canonical-Logo-Light%201.svg"
             alt="Canonical Logo"
             title="Canonical Logo">
         </th>

--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -23,9 +23,10 @@
         <td style="vertical-align: top;padding:0px; padding-left:5px;font-size: 0px;" colspan="2">
           <p
             style="display:inline-block;font-size:13px;line-height:16px;padding-top:0.8px;margin-bottom: 8px;margin-top:0.8px; color:#757575; font-weight:500;">
-            Visual Designer</p>
+            VP Engineering, Enterprise Solutions</p>
         </td>
       </tr>
+
       <tr>
         <td style="vertical-align: top; padding:0px; padding-left:5px; font-size: 0px;">
           <p
@@ -36,6 +37,18 @@
             <p
               style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px;margin-top:0.8px;margin-left: 12px;font-weight:500;">
               hadley.carlisle@canonical.com</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top; padding:0px; padding-left:5px; font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;color:#757575;font-weight:500;">
+            Mailing List: </p>
+        </td>
+        <td style="vertical-align:top; padding:0px; padding-left:5px;padding-right:4px;font-size: 0px;">
+            <p
+              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px;margin-top:0.8px;margin-left: 12px;font-weight:500;">
+              design.ops@canonical.com</p>
         </td>
       </tr>
 
@@ -64,6 +77,19 @@
             +1 2345 6789</p>
         </td>
       </tr>
+      <tr>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px; margin-top:0.8px;color:#757575; font-weight:500;">
+            Mobile:</p>
+        </td>
+        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
+          <p
+            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px; margin-top:0.8px;margin-left: 12px; font-weight:500;">
+            +1 2345 6789</p>
+        </td>
+      </tr>
+
       <tr>
         <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;" colspan="2">
           <a href="https://canonical.com/" style="color:#0066cc;text-decoration: none;">

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -190,7 +190,7 @@
     </div>
     <div class="col">
       <div class="p-media-container">
-        <iframe class="email-signature-frame" id="email-signature-frame" height="250px">
+        <iframe class="email-signature-frame" id="email-signature-frame" height="260px">
         </iframe>
       </div>
       <template id="email-signature-template">{% include "resources/_email-signature.html" %}</template>


### PR DESCRIPTION
## Done

- Replace email signature 20 year logo with the standard Canonical logo

## QA

- Navigate to [/resources](https://design-ubuntu-com-331.demos.haus/resources) and make sure the logo is replaced accordingly.

## Issue / Card

- [WD-18640](https://warthogs.atlassian.net/browse/WD-18640)

## Screenshots

Before:
![Screenshot from 2025-01-29 11-37-18](https://github.com/user-attachments/assets/16865b45-346f-40f1-95a5-0e9d1ca68d19)

After:
![image](https://github.com/user-attachments/assets/51034a07-35b3-447a-96f9-496d57d3e38e)





[WD-18640]: https://warthogs.atlassian.net/browse/WD-18640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ