### PR TITLE
fix: resolve logo not showing after email is sent

### DIFF
--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -7,7 +7,7 @@
           style="vertical-align:top;padding:0px;font-size: 0px; text-align: left;padding-top: 4px;padding-left: 4px;"
           colspan="2">
           <img height="40px" width="128px" style="margin-bottom: 17px;"
-            src="https://assets.ubuntu.com/v1/4677e80e-Canonical-Logo-Light%201.svg"
+            src="https://assets.ubuntu.com/v1/7620920d-Canonical-Logo-Light%201.png"
             alt="Canonical Logo"
             title="Canonical Logo">
         </th>


### PR DESCRIPTION
## Done

- Replace the email signature logo

## QA

- Copy the email signature and send a test email.
- Make sure the logo shows after the email is sent.

## Issue / Card

- [WD-18640](https://warthogs.atlassian.net/browse/WD-18640)


[WD-18640]: https://warthogs.atlassian.net/browse/WD-18640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ