### PR TITLE
fix(_email-signature.html): links appearing underlined

### DIFF
--- a/templates/resources/_email-signature.html
+++ b/templates/resources/_email-signature.html
@@ -1,101 +1,26 @@
 <div style="font-family: Ubuntu,sans-serif; margin:0px;">
-  <table
-    style="border-spacing:0px; border-width:0px; font-family: Ubuntu, sans-serif;margin:0px;color: #000; border-color:white;">
+  <table style="border-spacing:0px;
+                border-width:0px;
+                font-family: Ubuntu, sans-serif;
+                margin:0px;
+                color: #000;
+                border-color:white">
     <tbody>
       <tr>
-        <th
-          style="vertical-align:top;padding:0px;font-size: 0px; text-align: left;padding-top: 4px;padding-left: 4px;"
-          colspan="2">
-          <img height="40px" width="128px" style="margin-bottom: 17px;"
-            src="https://assets.ubuntu.com/v1/7620920d-Canonical-Logo-Light%201.png"
-            alt="Canonical Logo"
-            title="Canonical Logo">
+        <th style="vertical-align:top;
+                   padding:0px;
+                   font-size: 0px;
+                   text-align: left;
+                   padding-top: 4px;
+                   padding-left: 4px"
+            colspan="2">
+          <img height="40px"
+               width="128px"
+               style="margin-bottom: 17px"
+               src="https://assets.ubuntu.com/v1/7620920d-Canonical-Logo-Light%201.png"
+               alt="Canonical Logo"
+               title="Canonical Logo" />
         </th>
-      </tr>
-      <tr>
-        <td style="vertical-align: top;padding:0px; padding-left:5px; font-size: 0px;" colspan="2">
-          <p
-            style="display:inline-block;font-size:13px;line-height:16px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;font-weight:600;">
-            Hadley Carlisle</p>
-        </td>
-      </tr>
-      <tr>
-        <td style="vertical-align: top;padding:0px; padding-left:5px;font-size: 0px;" colspan="2">
-          <p
-            style="display:inline-block;font-size:13px;line-height:16px;padding-top:0.8px;margin-bottom: 8px;margin-top:0.8px; color:#757575; font-weight:500;">
-            VP Engineering, Enterprise Solutions</p>
-        </td>
-      </tr>
-
-      <tr>
-        <td style="vertical-align: top; padding:0px; padding-left:5px; font-size: 0px;">
-          <p
-            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;color:#757575;font-weight:500;">
-            Email: </p>
-        </td>
-        <td style="vertical-align:top; padding:0px; padding-left:5px;padding-right:4px;font-size: 0px;">
-            <p
-              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px;margin-top:0.8px;margin-left: 12px;font-weight:500;">
-              hadley.carlisle@canonical.com</p>
-        </td>
-      </tr>
-      <tr>
-        <td style="vertical-align: top; padding:0px; padding-left:5px; font-size: 0px;">
-          <p
-            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;color:#757575;font-weight:500;">
-            Mailing List: </p>
-        </td>
-        <td style="vertical-align:top; padding:0px; padding-left:5px;padding-right:4px;font-size: 0px;">
-            <p
-              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px;margin-top:0.8px;margin-left: 12px;font-weight:500;">
-              design.ops@canonical.com</p>
-        </td>
-      </tr>
-
-      <tr>
-        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
-          <p
-            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px;color:#757575; font-weight:500;">
-            Location:</p>
-        </td>
-        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
-          <p
-            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;;margin-top:0.8px;margin-left: 12px; font-weight:500;">
-            United Kingdom</p>
-        </td>
-      </tr>
-
-      <tr>
-        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
-          <p
-            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px; margin-top:0.8px;color:#757575; font-weight:500;">
-            Mobile:</p>
-        </td>
-        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;">
-          <p
-            style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom:0px; margin-top:0.8px;margin-left: 12px; font-weight:500;">
-            +1 2345 6789</p>
-        </td>
-      </tr>
-
-      <tr>
-        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;" colspan="2">
-          <a href="https://canonical.com/" target="_blank" style="color:#0066cc;text-decoration: none;">
-            <p
-              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:8.8px; font-weight:500;">
-              canonical.com</p>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td style="vertical-align: top;padding:0px;padding-left:5px;font-size: 0px;" colspan="2">
-          <a href="https://ubuntu.com/" target="_blank" style="color:#0066cc;text-decoration: none;">
-            <p
-              style="display: inline-block;font-size:13px;line-height:17px;padding-top:0.8px;margin-bottom: 0px;margin-top:0.8px; font-weight:500;">
-              ubuntu.com</p>
-          </a>
-        </td>
-        
       </tr>
       <tr>
         <td style="vertical-align: top;
@@ -103,23 +28,230 @@
                    padding-left:5px;
                    font-size: 0px"
             colspan="2">
+          <p style="display:inline-block;
+                    font-size:13px;
+                    line-height:16px;
+                    padding-top:0.8px;
+                    margin-bottom: 0px;
+                    margin-top:0.8px;
+                    font-weight:600">Hadley Carlisle</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px"
+            colspan="2">
+          <p style="display:inline-block;
+                    font-size:13px;
+                    line-height:16px;
+                    padding-top:0.8px;
+                    margin-bottom: 8px;
+                    margin-top:0.8px;
+                    color:#757575;
+                    font-weight:500">VP Engineering, Enterprise Solutions</p>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px">
           <p style="display: inline-block;
                     font-size:13px;
                     line-height:17px;
                     padding-top:0.8px;
                     margin-bottom: 0px;
-                    margin-top:8px;
-                    font-weight:500">
-            <a href="https://canonical.com/careers?utm_source=signature&utm_medium=email"
-               target="_blank"
-               style="color:#0066cc; 
-                      text-decoration: none">We are hiring</a>
-            <span style="color: #757575;">|</span>
-            <a href="https://www.linkedin.com/company/canonical/life/"
-               target="_blank"
-               style="color:#0066cc; 
-                      text-decoration: none">Life at Canonical</a>
-          </p>
+                    margin-top:0.8px;
+                    color:#757575;
+                    font-weight:500">Email:</p>
+        </td>
+        <td style="vertical-align:top;
+                   padding:0px;
+                   padding-left:5px;
+                   padding-right:4px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom:0px;
+                    margin-top:0.8px;
+                    margin-left: 12px;
+                    font-weight:500">hadley.carlisle@canonical.com</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom: 0px;
+                    margin-top:0.8px;
+                    color:#757575;
+                    font-weight:500">Mailing List:</p>
+        </td>
+        <td style="vertical-align:top;
+                   padding:0px;
+                   padding-left:5px;
+                   padding-right:4px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom:0px;
+                    margin-top:0.8px;
+                    margin-left: 12px;
+                    font-weight:500">design.ops@canonical.com</p>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom: 0px;
+                    margin-top:0.8px;
+                    color:#757575;
+                    font-weight:500">Location:</p>
+        </td>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom: 0px;
+                    margin-top:0.8px;
+                    margin-left: 12px;
+                    font-weight:500">United Kingdom</p>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom:0px;
+                    margin-top:0.8px;
+                    color:#757575;
+                    font-weight:500">Mobile:</p>
+        </td>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px">
+          <p style="display: inline-block;
+                    font-size:13px;
+                    line-height:17px;
+                    padding-top:0.8px;
+                    margin-bottom:0px;
+                    margin-top:0.8px;
+                    margin-left: 12px;
+                    font-weight:500">+1 2345 6789</p>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px"
+            colspan="2">
+          <a href="https://canonical.com/"
+             target="_blank"
+             style="color:#0066cc;
+                    text-decoration: none">
+            <p style="display: inline-block;
+                      font-size:13px;
+                      line-height:17px;
+                      padding-top:0.8px;
+                      margin-bottom: 0px;
+                      margin-top:8.8px;
+                      font-weight:500">canonical.com</p>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px"
+            colspan="2">
+          <a href="https://ubuntu.com/"
+             target="_blank"
+             style="color:#0066cc;
+                    text-decoration: none">
+            <p style="display: inline-block;
+                      font-size:13px;
+                      line-height:17px;
+                      padding-top:0.8px;
+                      margin-bottom: 0px;
+                      margin-top:0.8px;
+                      font-weight:500">ubuntu.com</p>
+          </a>
+        </td>
+
+      </tr>
+      <tr>
+        <td style="vertical-align: top;
+                   padding:0px;
+                   padding-left:5px;
+                   font-size: 0px"
+            colspan="2">
+          <a href="https://canonical.com/careers?utm_source=signature&utm_medium=email"
+             target="_blank"
+             style="color:#0066cc;
+                    text-decoration: none">
+            <p style="display: inline-block;
+                      font-size:13px;
+                      line-height:17px;
+                      padding-top:0.8px;
+                      margin-bottom: 0px;
+                      margin-top:8px;
+                      font-weight:500">We are hiring</p>
+          </a>
+          <span style="display: inline-block;
+                       font-size:13px;
+                       line-height:17px;
+                       padding-top:0.8px;
+                       padding-left: 3px;
+                       padding-right: 3px;
+                       margin-bottom: 0px;
+                       margin-top:8px;
+                       font-weight:500;
+                       color: #757575">|</span>
+          <a href="https://www.linkedin.com/company/canonical/life/"
+             target="_blank"
+             style="color:#0066cc;
+                    text-decoration: none">
+            <p style="display: inline-block;
+                      font-size:13px;
+                      line-height:17px;
+                      padding-top:0.8px;
+                      margin-bottom: 0px;
+                      margin-top:8px;
+                      font-weight:500">Life at Canonical</p>
+          </a>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Problem statement

- On some browsers the 'Life and Canonical' and 'We are hiring' links appeared underlined. See [ticket](https://warthogs.atlassian.net/browse/WD-33997) for more details

## Done

- I have updated the HTML structure to match the canonical.com and ubuntu.com links that are not aligned.

## QA

- Check out this feature branch locally and `dotrun`
- http://0.0.0.0:8011/resources#logos
- Check it matches the design on https://design.ubuntu.com/resources#email-signature-frame

## Issue / Card

Fixes [# [WD-](https://warthogs.atlassian.net/browse/WD-)](https://warthogs.atlassian.net/browse/WD-33997)

